### PR TITLE
Return bytes instead of decoded string

### DIFF
--- a/hbp_service_client/document_service/client.py
+++ b/hbp_service_client/document_service/client.py
@@ -819,7 +819,7 @@ class Client(object):
             etag = resp.headers['ETag']
         else:
             raise DocException('No ETag received from the service with the download')
-        return (etag, resp.text)
+        return (etag, resp.content)
 
     def get_signed_url(self, file_id):
         '''Get a signed unauthenticated URL.

--- a/hbp_service_client/version.py
+++ b/hbp_service_client/version.py
@@ -1,2 +1,2 @@
 '''version string'''
-VERSION = "0.0.1"
+VERSION = "0.0.2.dev1"


### PR DESCRIPTION
when downloading file contents